### PR TITLE
Feature/revenuecat attribute cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,21 +725,39 @@ Learn more: [Short Codes Documentation](https://docs.insertaffiliate.com/short-c
 Automatically apply discounts or trials when users come from specific affiliates.
 
 **How It Works:**
-1. Configure an offer code modifier in your dashboard (e.g., `_oneWeekFree`)
+1. Configure an offer code modifier in your dashboard (e.g., `oneWeekFree`)
 2. SDK automatically fetches and stores the modifier when affiliate identifier is set
-3. Use the modifier to construct dynamic product IDs
+3. The `affiliateOfferCode` attribute is set in RevenueCat for targeting
 
-**Quick Example:**
+#### Option 1: RevenueCat Targeting (Recommended)
+
+Use RevenueCat's targeting feature to automatically show different offerings based on the `affiliateOfferCode` attribute. No manual product ID construction needed.
+
+**Step 1:** Create offerings in RevenueCat (e.g., `default` and `oneWeekFree`)
+
+**Step 2:** Configure targeting rules in RevenueCat:
+- Condition: `affiliateOfferCode` is any of `oneWeekFree`
+- Show Offering: Select your promotional offering
+
+**Step 3:** Just use `offerings.current` in your app:
+
+```dart
+final offerings = await Purchases.getOfferings();
+final packages = offerings.current?.availablePackages ?? [];
+// RevenueCat targeting automatically shows the right offering!
+```
+
+#### Option 2: Manual Product ID Construction (Alternative)
+
+If not using RevenueCat targeting, you can manually construct product IDs:
 
 ```dart
 String? offerCode = await insertAffiliateSdk.getStoredOfferCode();
 
 final baseProductId = "oneMonthSubscription";
 final dynamicProductId = offerCode != null
-    ? '$baseProductId$offerCode'  // e.g., "oneMonthSubscription_oneWeekFree"
+    ? '${baseProductId}_$offerCode'  // e.g., "oneMonthSubscription_oneWeekFree"
     : baseProductId;
-
-// Use dynamicProductId when fetching/purchasing products
 ```
 
 📖 **[View complete Dynamic Offer Codes guide →](docs/dynamic-offer-codes.md)**

--- a/README.md
+++ b/README.md
@@ -150,11 +150,16 @@ class _MyAppState extends State<MyApp> {
     await Purchases.configure(PurchasesConfiguration("YOUR_REVENUECAT_API_KEY"));
 
     // Set up callback to sync affiliate identifier to RevenueCat whenever it changes
+    // Note: Use preventAffiliateTransfer in constructor to block affiliate changes in the SDK
     insertAffiliateSdk.setInsertAffiliateIdentifierChangeCallback((identifier, offerCode) async {
       if (identifier == null) return;
 
       // Ensure subscriber exists by fetching customer info first
-      await Purchases.getCustomerInfo();
+      final customerInfo = await Purchases.getCustomerInfo();
+
+      // OPTIONAL: Prevent attribution for existing subscribers
+      // Uncomment to ensure affiliates only earn from users they actually brought:
+      // if (customerInfo.entitlements.active.isNotEmpty) return; // User already subscribed, don't attribute
 
       // Get expiry timestamp for insert_timedout
       final expiryTimestamp = await insertAffiliateSdk.getAffiliateExpiryTimestamp();


### PR DESCRIPTION
Resolves three things:

1. RevenueCat affiliateAttributionActiveTime - this modified approach ensures that only new transactions are prevented from being logged after the timeout has expired whilst still allowing renewals to continue (to modify renewals length, use https://docs.insertaffiliate.com/renewal-attribution-window)

2. We've added a way for you to prevent one affiliate hijacking transactions from another by first checking if one was already set. This is optional, some users wish to reward the affiliate that got a user to go back to the app most recently - some want the first affiliate that got the initial transaction to continue receiving their earned rewards.

3. We've added a way in our documentation for you to prevent an affiliate taking renewals they did not earn (a subscription that occurred before the link was clicked). This is once again optional, we advise you pay affiliates the renewals if they encourage the user to return to the app if your goal is to get the affiliate to time to first pound as quickly as possible.

By allowing this, you may encourage bad actors to advertise to try and get your existing subscribers to click their links for a payment - from our experience, your users like your app and what you do if they're paying for it, and would very likely report this sort of action to you quite quickly, allowing you to remove that bad actor whilst still rewarding other affiliates.

2 and 3 from this list are business decisions - we can only advise here from our experience, but we will leave you with the flexibility to make the decision which suits your app best.