### PR TITLE
Only send system info on first launch after install

### DIFF
--- a/lib/insert_affiliate_flutter_sdk.dart
+++ b/lib/insert_affiliate_flutter_sdk.dart
@@ -90,11 +90,15 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
       }
       
       if (Platform.isIOS) {
-        try {
-          final enhancedSystemInfo = await getEnhancedSystemInfo();
-          await sendSystemInfoToBackend(enhancedSystemInfo);
-        } catch (error) {
-          verboseLog('Error sending system info for clipboard check: $error');
+        final prefs = await SharedPreferences.getInstance();
+        final systemInfoSent = prefs.getBool('system_info_sent') ?? false;
+        if (!systemInfoSent) {
+          try {
+            final enhancedSystemInfo = await getEnhancedSystemInfo();
+            await sendSystemInfoToBackend(enhancedSystemInfo);
+          } catch (error) {
+            verboseLog('Error sending system info for clipboard check: $error');
+          }
         }
       }
     }
@@ -1363,6 +1367,8 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
       }
 
       if (response.statusCode >= 200 && response.statusCode <= 299) {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('system_info_sent', true);
         verboseLog('System info sent successfully');
       } else {
         verboseLog('Failed to send system info with status code: ${response.statusCode}');

--- a/lib/insert_affiliate_flutter_sdk.dart
+++ b/lib/insert_affiliate_flutter_sdk.dart
@@ -954,13 +954,7 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
     // Store the short code as the referring link
     await storeInsertAffiliateIdentifier(link: upperCaseShortCode, source: AffiliateAssociationSource.deepLinkIos);
 
-    // Collect and send enhanced system info to backend
-    try {
-      final enhancedSystemInfo = await getEnhancedSystemInfo();
-      await sendSystemInfoToBackend(enhancedSystemInfo);
-    } catch (error) {
-      verboseLog('Error sending system info for deep link: $error');
-    }
+    // System info not needed here - affiliate code already received via URL scheme
 
     return true;
   }


### PR DESCRIPTION
## Summary
- System info for deferred deep link matching is now sent only once per install
- On successful send, a flag is persisted to SharedPreferences to prevent redundant network calls on subsequent launches
- If the send fails, the flag is not set so it retries on next launch
- Removed unnecessary system info call from custom URL scheme handler

## Test plan
- [x] Fresh install: system info sent, clipboard match score 100
- [x] Direct deep link via URL scheme: affiliate set, no system info sent
- [x] Affiliate replacement: clicking different link replaces stored affiliate