### PR TITLE
Add Universal Links and Android App Links support

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,43 @@ void _setupDeepLinkListener() async {
 }
 ```
 
+#### Universal Links (Optional, Recommended)
+
+Universal Links provide a better user experience than custom URL schemes. When a user taps an Insert Link and already has your app installed, iOS opens the app directly — without loading the browser.
+
+**Prerequisites:**
+- Enter your **Apple Team ID** and **iOS Bundle Identifier** in the Insert Affiliate dashboard settings
+
+**Step 1: Add Associated Domains in Xcode**
+
+Go to your app target → **Signing & Capabilities** → **+ Capability** → **Associated Domains**.
+
+Add:
+```
+applinks:insertaffiliate.link
+```
+
+If you have a custom domain (e.g. `links.yourcompany.com`), also add:
+```
+applinks:links.yourcompany.com
+```
+
+**Step 2: Handle Universal Links in your app**
+
+The `app_links` package used above already handles Universal Links — both `getInitialLink()` and `uriLinkStream` receive Universal Link URLs. The SDK's `handleDeepLink()` method routes them to the correct handler automatically. No additional code changes needed.
+
+> **Note:** Universal Links won't trigger if you type the URL directly into Safari's address bar — tap it from **Notes or Messages** for a real test.
+
+**Testing Universal Links:**
+
+```bash
+# iOS Simulator
+xcrun simctl openurl booted "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
+
+# Real device (get UDID from: xcrun devicectl list devices)
+xcrun devicectl device process launch -d YOUR_DEVICE_UDID com.apple.mobilesafari "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
+```
+
 ✅ **Insert Links setup complete!**
 
 </details>

--- a/README.md
+++ b/README.md
@@ -584,6 +584,41 @@ xcrun simctl openurl booted "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST
 xcrun devicectl device process launch -d YOUR_DEVICE_UDID com.apple.mobilesafari "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
 ```
 
+#### Android App Links (Optional, Recommended)
+
+Android App Links provide a better user experience than custom URL schemes. When a user taps an Insert Link and already has your app installed, Android opens the app directly — without loading the browser or showing a disambiguation dialog.
+
+**Prerequisites:**
+- Enter your **Android Bundle Identifier** (package name) and **SHA-256 Certificate Fingerprints** in the Insert Affiliate dashboard settings
+
+**Step 1: Add intent filter to AndroidManifest.xml**
+
+Add this inside your main `<activity>` tag in `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https" android:host="insertaffiliate.link" />
+</intent-filter>
+```
+
+If you have a custom domain, add another intent filter with your domain.
+
+**Step 2: Set launch mode**
+
+Add `android:launchMode="singleTop"` to your main activity to prevent it being recreated when an App Link is tapped:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTop"
+    ...>
+```
+
+> No additional code changes needed — the `app_links` package already receives App Link URLs and the SDK routes them to the correct handler automatically.
+
 ✅ **Insert Links setup complete!**
 
 </details>

--- a/README.md
+++ b/README.md
@@ -559,7 +559,16 @@ If you have a custom domain (e.g. `links.yourcompany.com`), also add:
 applinks:links.yourcompany.com
 ```
 
-**Step 2: Handle Universal Links in your app**
+**Step 2: Disable Flutter's built-in deep link handling**
+
+Add this to your `ios/Runner/Info.plist` to prevent Flutter's engine from trying to route Universal Link URLs (which causes Safari to open after the SDK handles the link):
+
+```xml
+<key>FlutterDeepLinkingEnabled</key>
+<false/>
+```
+
+**Step 3: Handle Universal Links in your app**
 
 The `app_links` package used above already handles Universal Links — both `getInitialLink()` and `uriLinkStream` receive Universal Link URLs. The SDK's `handleDeepLink()` method routes them to the correct handler automatically. No additional code changes needed.
 

--- a/lib/insert_affiliate_flutter_sdk.dart
+++ b/lib/insert_affiliate_flutter_sdk.dart
@@ -23,6 +23,7 @@ enum AffiliateAssociationSource {
   shortCodeManual,   // Developer called setShortCode()
   referringLink,     // Developer called setInsertAffiliateIdentifier()
   universalLink,     // iOS Universal Link (https://insertaffiliate.link/companycode/shortcode)
+  appLink,           // Android App Link (https://insertaffiliate.link/companycode/shortcode)
 }
 
 /// Affiliate details returned from the API
@@ -221,6 +222,8 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
         return 'referring_link';
       case AffiliateAssociationSource.universalLink:
         return 'universal_link';
+      case AffiliateAssociationSource.appLink:
+        return 'app_link';
     }
   }
 
@@ -852,6 +855,14 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
   // MARK: Platform Routing
   Future<bool> handleDeepLink(String url) async {
     verboseLog('Platform detection: Platform.OS = ${Platform.operatingSystem}');
+
+    // App Links (Android) and Universal Links (iOS) both use https://
+    // Route these through handleInsertLinks which handles both
+    if (url.startsWith('https://') || url.startsWith('http://')) {
+      verboseLog('Routing https URL to handleInsertLinks');
+      return await handleInsertLinks(url);
+    }
+
     if (Platform.isIOS) {
       verboseLog('Routing to iOS handler (handleInsertLinks)');
       return await handleInsertLinks(url);
@@ -945,7 +956,7 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
         verboseLog('Warning: URL company code ($urlCompanyCode) doesn\'t match initialized company code ($activeCompanyCode)');
       }
 
-      await storeInsertAffiliateIdentifier(link: shortCode.toUpperCase(), source: AffiliateAssociationSource.universalLink);
+      await storeInsertAffiliateIdentifier(link: shortCode.toUpperCase(), source: Platform.isAndroid ? AffiliateAssociationSource.appLink : AffiliateAssociationSource.universalLink);
       return true;
     } catch (error) {
       print('[Insert Affiliate] Error handling universal link: $error');
@@ -976,7 +987,7 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
       }
 
       verboseLog('Custom domain universal link detected - Short code: $shortCode');
-      await storeInsertAffiliateIdentifier(link: shortCode.toUpperCase(), source: AffiliateAssociationSource.universalLink);
+      await storeInsertAffiliateIdentifier(link: shortCode.toUpperCase(), source: Platform.isAndroid ? AffiliateAssociationSource.appLink : AffiliateAssociationSource.universalLink);
       return true;
     } catch (error) {
       print('[Insert Affiliate] Error handling custom domain universal link: $error');

--- a/lib/insert_affiliate_flutter_sdk.dart
+++ b/lib/insert_affiliate_flutter_sdk.dart
@@ -22,6 +22,7 @@ enum AffiliateAssociationSource {
   clipboardMatch,    // iOS clipboard UUID match from backend
   shortCodeManual,   // Developer called setShortCode()
   referringLink,     // Developer called setInsertAffiliateIdentifier()
+  universalLink,     // iOS Universal Link (https://insertaffiliate.link/companycode/shortcode)
 }
 
 /// Affiliate details returned from the API
@@ -218,6 +219,8 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
         return 'short_code_manual';
       case AffiliateAssociationSource.referringLink:
         return 'referring_link';
+      case AffiliateAssociationSource.universalLink:
+        return 'universal_link';
     }
   }
 
@@ -879,7 +882,17 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
       return await handleCustomURLScheme(url, urlObj['protocol']!);
     }
 
-    // Universal links handling would go here for future implementation
+    // Handle universal links from insertaffiliate.link
+    if (urlObj['protocol'] == 'https:' && (urlObj['hostname']?.contains('insertaffiliate.link') == true)) {
+      return await handleUniversalLink(url);
+    }
+
+    // Handle universal links from any https domain (custom domains)
+    // iOS only delivers universal links for domains in Associated Domains entitlement
+    if (urlObj['protocol'] == 'https:') {
+      return await handleCustomDomainUniversalLink(url);
+    }
+
     return false;
   }
 
@@ -898,6 +911,76 @@ class InsertAffiliateFlutterSDK extends ChangeNotifier {
         'hostname': '',
         'href': url,
       };
+    }
+  }
+
+  // MARK: Universal Link Handler
+  /// Handle universal links like https://insertaffiliate.link/companycode/shortcode
+  /// Also supports legacy format: https://insertaffiliate.link/V1/companycode/shortcode
+  Future<bool> handleUniversalLink(String url) async {
+    try {
+      final uri = Uri.parse(url);
+      final pathComponents = uri.pathSegments;
+
+      String urlCompanyCode;
+      String shortCode;
+
+      if (pathComponents.length >= 3 && pathComponents[0] == 'V1') {
+        // Legacy format: /V1/companycode/shortcode
+        urlCompanyCode = pathComponents[1];
+        shortCode = pathComponents[2];
+      } else if (pathComponents.length >= 2) {
+        // Current format: /companycode/shortcode
+        urlCompanyCode = pathComponents[0];
+        shortCode = pathComponents[1];
+      } else {
+        print('[Insert Affiliate] Invalid universal link format: $url');
+        return false;
+      }
+
+      verboseLog('Universal link detected - Company: $urlCompanyCode, Short code: $shortCode');
+
+      final activeCompanyCode = await getActiveCompanyCode();
+      if (activeCompanyCode != null && urlCompanyCode.toLowerCase() != activeCompanyCode.toLowerCase()) {
+        verboseLog('Warning: URL company code ($urlCompanyCode) doesn\'t match initialized company code ($activeCompanyCode)');
+      }
+
+      await storeInsertAffiliateIdentifier(link: shortCode.toUpperCase(), source: AffiliateAssociationSource.universalLink);
+      return true;
+    } catch (error) {
+      print('[Insert Affiliate] Error handling universal link: $error');
+      return false;
+    }
+  }
+
+  /// Handle universal links from custom domains (e.g. https://links.yourcompany.com/companycode/shortcode)
+  /// iOS only delivers universal links for domains in the app's Associated Domains entitlement
+  Future<bool> handleCustomDomainUniversalLink(String url) async {
+    try {
+      final uri = Uri.parse(url);
+      final pathComponents = uri.pathSegments;
+
+      if (pathComponents.length < 2) {
+        return false;
+      }
+
+      final urlCompanyCode = pathComponents[0];
+      final shortCode = pathComponents[1];
+
+      final activeCompanyCode = await getActiveCompanyCode();
+      if (activeCompanyCode == null) return false;
+
+      if (urlCompanyCode.toLowerCase() != activeCompanyCode.toLowerCase()) {
+        verboseLog('Custom domain universal link company code ($urlCompanyCode) doesn\'t match initialized company code ($activeCompanyCode), ignoring');
+        return false;
+      }
+
+      verboseLog('Custom domain universal link detected - Short code: $shortCode');
+      await storeInsertAffiliateIdentifier(link: shortCode.toUpperCase(), source: AffiliateAssociationSource.universalLink);
+      return true;
+    } catch (error) {
+      print('[Insert Affiliate] Error handling custom domain universal link: $error');
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `universalLink` and `appLink` source types with platform-aware routing
- Implement `handleUniversalLink` and `handleCustomDomainUniversalLink`
- Route Android `https://` URLs through `handleInsertLinks` for App Links
- Update README with Associated Domains, `FlutterDeepLinkingEnabled`, AndroidManifest intent filters

## Test plan
- [x] Tested iOS Universal Links on iPhone (default + custom domain)
- [x] Tested Android App Links on Samsung device (default + custom domain)
- [x] Google Digital Asset Links verification passing